### PR TITLE
cyclecmd: v0.2.0 release content

### DIFF
--- a/CHANGELOG/v0.2.0.md
+++ b/CHANGELOG/v0.2.0.md
@@ -1,0 +1,7 @@
+# v0.2.0
+## Features
+- Introduced `ControlEvent` to influence application control flow; currently supports application termination via `CYCLE_TERMINATE` constant
+## Enhancements
+- Enhanced event loop to capture up to 3 bytes per input, enabling support for escape sequences such as arrow keys
+## Bug Fixes
+## Notes

--- a/LICENSE
+++ b/LICENSE
@@ -175,7 +175,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright [2024] [RaphSku]
+   Copyright 2025 RaphSku
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # cyclecmd
 ## Description
-cyclecmd helps you to write console applications based on events that are triggered by the user input. It is an unopinionated library, thus you can define events in any way that you need.
+cyclecmd helps you to write console applications based on events that are triggered by user input. It is an unopinionated library, thus you can define events in any way that you need.
 
 ## How to get it
 You can get cyclecmd with the following command:
@@ -9,22 +9,23 @@ go get github.com/RaphSku/cyclecmd@latest
 ```
 
 ## How to use it
-First of all, you have to define a default event that will be triggered by any user input that does not trigger any other registered event. For this example, let's print the user input (that we call token) on our default event.
+First, define a default event that will be triggered whenever user input doesn't match any other registered event. In this example, the default event will simply print the user's input (referred to as the "token").
 ```Go
 type DefaultEvent struct{}
 
-func (de *DefaultEvent) Handle(token string) error {
+func (de *DefaultEvent) Handle(token string) (error, *cyclecmd.ControlEvent) {
 	fmt.Print(token)
 	return nil
 }
 ```
-Note, that all events have to comply with the following interface:
+**Note**, that all events have to comply with the following interface:
 ```Go
 type Event interface {
-    Handle(token string) error
+    Handle(token string) (error, *ControlEvent)
 }
 ```
-The default event is the only event that we are required to create, because we can initialize the event registry with this event:
+Additionally, every `Handle` function returns an error and a `ControlEvent`, which can be used to instruct cyclecmd to trigger a specific event that may alter the application's flow. In the current version, however, the only available control event is for terminating the application (via the constant `CYCLE_TERMINATE`).
+The default event is the only required event, as it serves to initialize the event registry and ensure there's always a fallback handler for unrecognized input:
 ```Go
 defaultEventInformation := cyclecmd.EventInformation{
     EventName: "Default",
@@ -36,7 +37,7 @@ For demonstration purposes, let us register another event, the backspace event t
 ```Go
 type BackspaceEvent struct{}
 
-func (be *BackspaceEvent) Handle(token string) error {
+func (be *BackspaceEvent) Handle(token string) (error, *cyclecmd.ControlEvent) {
 	fmt.Print("\b \b")
 	return nil
 }
@@ -54,7 +55,6 @@ eventHistory := cyclecmd.NewEventHistory()
 And with the event registry and event history we can finally initialise our console app and let it run and handle our custom events.
 ```Go
 consoleApp := cyclecmd.NewConsoleApp(
-    context.Background(),
     "Test",
     "v0.1.0",
     "Example description...",
@@ -64,7 +64,7 @@ consoleApp := cyclecmd.NewConsoleApp(
 consoleApp.SetLineDelimiter("\n\r>>> ", "\x7f")
 consoleApp.Start()
 ```
-Note, that we can also set a line delimiter that will print in our case "\n\r>>> ". Be ware, that you have to add "\n\r" to the delimiter if you want to print a new line where each line begins with >>>. This is intentional, such that you can define any delimiter that you want, even ones with no new lines if that is what you require. The `Start()` method will kick off the event loop. 
+Note that you can also set a line delimiter—for example, `"\n\r>>> "` in this case. If you want each new line to begin with `>>>`, be sure to include `"\n\r"` in the delimiter. This design is intentional, allowing you to customize the delimiter freely, even omitting new lines if needed. Finally, calling the `Start()` method begins the event loop.
 
 ## Example Projects
 If you want to see a complete example on how to leverage cyclecmd, please have a look at the following projects that use cyclecmd: 

--- a/app_test.go
+++ b/app_test.go
@@ -3,7 +3,6 @@
 package cyclecmd_test
 
 import (
-	"context"
 	"os"
 	"os/exec"
 	"testing"
@@ -15,12 +14,10 @@ import (
 func TestConsoleAppCreation(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	eventRegistry := cyclecmd.NewEventRegistry(setupDefaultEventInformation())
 	eventHistory := cyclecmd.NewEventHistory()
 
 	actConsoleApp := cyclecmd.NewConsoleApp(
-		ctx,
 		"test",
 		"0.1.0",
 		"This is a test console application",
@@ -41,12 +38,10 @@ func TestConsoleAppCreation(t *testing.T) {
 func TestChangeToDebugMode(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	eventRegistry := cyclecmd.NewEventRegistry(setupDefaultEventInformation())
 	eventHistory := cyclecmd.NewEventHistory()
 
 	consoleApp := cyclecmd.NewConsoleApp(
-		ctx,
 		"test",
 		"0.1.0",
 		"This is a test console application",
@@ -65,7 +60,6 @@ func TestChangeToDebugMode(t *testing.T) {
 func TestSetLineDelimiter(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
 	eventRegistry := cyclecmd.NewEventRegistry(setupDefaultEventInformation())
 
 	expEventTrigger := "z"
@@ -78,7 +72,6 @@ func TestSetLineDelimiter(t *testing.T) {
 	eventHistory := cyclecmd.NewEventHistory()
 
 	consoleApp := cyclecmd.NewConsoleApp(
-		ctx,
 		"test",
 		"0.1.0",
 		"This is a test console application",
@@ -97,12 +90,10 @@ func TestSetLineDelimiterNotInRegistry(t *testing.T) {
 	t.Parallel()
 
 	if os.Getenv("UT_SetLineDelimiterNotInRegistry") == "1" {
-		ctx := context.Background()
 		eventRegistry := cyclecmd.NewEventRegistry(setupDefaultEventInformation())
 		eventHistory := cyclecmd.NewEventHistory()
 
 		consoleApp := cyclecmd.NewConsoleApp(
-			ctx,
 			"test",
 			"0.1.0",
 			"This is a test console application",

--- a/control_events.go
+++ b/control_events.go
@@ -1,0 +1,36 @@
+package cyclecmd
+
+const (
+	// CYCLE_TERMINATE is a flag indicating the termination event.
+	// It has the integer value 1.
+	CYCLE_TERMINATE int = 1
+)
+
+// ControlEvent represents control signals with boolean flags.
+//
+// Currently, it contains a single flag:
+//   - Terminate: true if the termination flag is set.
+type ControlEvent struct {
+	Terminate bool
+}
+
+// NewControlEvent creates a new ControlEvent from the given flags integer.
+//
+// It checks if the TERMINATE bit is set in the flags and sets the
+// Terminate field accordingly.
+//
+// Parameters:
+//   - `flags` : A number of control events whose bit should be set
+//
+// Returns:
+//   - `*ControlEvent` : A ControlEvent structure that captures all the control events that are activated or deactivated
+func NewControlEvent(flags int) *ControlEvent {
+	controlEvent := &ControlEvent{}
+
+	controlEvent.Terminate = false
+	if flags&CYCLE_TERMINATE != 0 {
+		controlEvent.Terminate = true
+	}
+
+	return controlEvent
+}

--- a/event_definition.go
+++ b/event_definition.go
@@ -6,9 +6,9 @@ package cyclecmd
 // Event expects the following method to be implemented by all events:
 //
 // Behavior:
-//   - `Handle(token string) error` : it expects the token that is associated with the event
+//   - `Handle(token string) (error, *ControlEvent)` : it expects the token that is associated with the event
 type Event interface {
-	Handle(token string) error
+	Handle(token string) (error, *ControlEvent)
 }
 
 // EventInformation stores the event itself but also the event name that was given to the custom event.

--- a/event_registry_test.go
+++ b/event_registry_test.go
@@ -91,29 +91,3 @@ func TestNoDefaultEventInRegistry(t *testing.T) {
 		assert.Equal(t, fmt.Errorf("default event is not set! Please set it via InitEventRegistry"), err)
 	}
 }
-
-func TestValidatingEventTriggerInEventMatching(t *testing.T) {
-	t.Parallel()
-
-	eventRegistry := cyclecmd.NewEventRegistry(setupDefaultEventInformation())
-	actEventInformation, err := eventRegistry.GetMatchingEventInformation("default")
-	assert.Equal(t, cyclecmd.EventInformation{}, actEventInformation)
-	if assert.Error(t, err) {
-		assert.Equal(t, fmt.Errorf("ensure that the eventTrigger represents just one token ([]byte length of 1)"), err)
-	}
-}
-
-func TestValidatingEventTriggerInEventRegistering(t *testing.T) {
-	t.Parallel()
-
-	eventRegistry := cyclecmd.NewEventRegistry(setupDefaultEventInformation())
-
-	eventInformation := cyclecmd.EventInformation{
-		EventName: "Test",
-		Event:     &TestEvent{},
-	}
-	err := eventRegistry.RegisterEvent("default", eventInformation)
-	if assert.Error(t, err) {
-		assert.Equal(t, fmt.Errorf("ensure that the eventTrigger represents just one token ([]byte length of 1)"), err)
-	}
-}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/RaphSku/cyclecmd
 
-go 1.21.0
+go 1.24.2
 
 require github.com/stretchr/testify v1.9.0
 

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.9.0 h1:HtqpIVDClZ4nwg75+f6Lvsy/wHu+3BoSGCbBAcpTsTg=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.10.0 h1:S0h4aNzvfcFsC3dRF1jLoaov7oRaKqRGC/pUEJ2yvPQ=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.27.0 h1:aJMhYGrd5QSmlpLMr2MftRKl7t8J8PTZPA732ud/XR8=
@@ -12,6 +14,7 @@ golang.org/x/sys v0.21.0 h1:rF+pYz3DAGSQAxAu1CbC7catZg4ebC4UIeIhKxBZvws=
 golang.org/x/sys v0.21.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.21.0 h1:WVXCp+/EBEHOj53Rvu+7KiT/iElMrO8ACK16SMZ3jaA=
 golang.org/x/term v0.21.0/go.mod h1:ooXLefLobQVslOqselCNF4SxFAaoS6KujMbsGzSDmX0=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/shared_resources_test.go
+++ b/shared_resources_test.go
@@ -11,9 +11,9 @@ import (
 
 type DefaultEvent struct{}
 
-func (de *DefaultEvent) Handle(token string) error {
+func (de *DefaultEvent) Handle(token string) (error, *cyclecmd.ControlEvent) {
 	fmt.Print(token)
-	return nil
+	return nil, nil
 }
 
 func setupDefaultEventInformation() cyclecmd.EventInformation {
@@ -25,16 +25,16 @@ func setupDefaultEventInformation() cyclecmd.EventInformation {
 
 type TestEvent struct{}
 
-func (te *TestEvent) Handle(token string) error {
+func (te *TestEvent) Handle(token string) (error, *cyclecmd.ControlEvent) {
 	fmt.Print("Testing this event")
-	return nil
+	return nil, nil
 }
 
 type BackspaceEvent struct{}
 
-func (be *BackspaceEvent) Handle(token string) error {
+func (be *BackspaceEvent) Handle(token string) (error, *cyclecmd.ControlEvent) {
 	fmt.Print("\b \b")
-	return nil
+	return nil, nil
 }
 
 func captureStdOutput(f func()) (string, error) {


### PR DESCRIPTION
[FEATURES]:
Added ControlEvents as an additional return type for the Event handler function in order for the user to be able to influence the control flow of the application, e.g. terminating it.

[ENHANCEMENTS]:
The event loop captured only 1 byte before, this is enough for characters but not enough for escape sequences that are e.g. 3 bytes long. Thus, the event loop is now able to capture 3 bytes but this introduced timing issues that needs to be resolved in the future by separating parsing from reading data.

[TESTS]:
Needed to change e2e test since user input was simulated by redirecting standard input to read from a file but the buffer will always fill when enough bytes are available but this does not reflect terminal user input behavior, so this was exchanged with os.Pipe and a time delay between each input. Removed test cases that checked the validation function that was removed.